### PR TITLE
fix: accept inline system/developer roles in Anthropic requests

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -412,6 +412,17 @@ func decodeBridgeRequest(protocol Protocol, input map[string]any) (bridgeRequest
 				return request, fmt.Errorf("messages[%d] must be an object", i)
 			}
 			role := stringAt(message, "role")
+			// Some clients (e.g. Claude Code) inline system/developer messages
+			// into the messages array instead of using the top-level system
+			// field. Fold them into the system prompt rather than rejecting.
+			if role == "system" {
+				request.System = append(request.System, decodeAnthropicBlocks(message["content"])...)
+				continue
+			}
+			if role == "developer" {
+				request.Developer = append(request.Developer, decodeAnthropicBlocks(message["content"])...)
+				continue
+			}
 			if role != "user" && role != "assistant" {
 				return request, fmt.Errorf("messages[%d] has unsupported role %q", i, role)
 			}


### PR DESCRIPTION
## Summary

- accept `system` and `developer` roles inside the Anthropic `messages` array, folding them into the top-level system/developer instructions instead of rejecting the request
- match the existing Chat Completions and Responses decoders, which already handle both roles the same way
- unblock clients such as Claude Code that inline a system message into `messages` rather than using the top-level `system` field - these currently fail with `400 messages[0] has unsupported role "system"`

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- manual: `POST /v1/messages` with `messages[0].role = "system"` now returns 200 and the system prompt is honored (previously 400)