### PR TITLE
fix: fetch models.dev metadata through configured proxies

### DIFF
--- a/model_metadata.go
+++ b/model_metadata.go
@@ -55,14 +55,15 @@ type modelMetadataCache struct {
 }
 
 type modelMetadataStore struct {
-	mu        sync.RWMutex
-	models    map[string]ModelPrice
-	updatedAt time.Time
-	lastError string
-	cachePath string
-	endpoint  string
-	client    *http.Client
-	logger    *slog.Logger
+	mu             sync.RWMutex
+	models         map[string]ModelPrice
+	updatedAt      time.Time
+	lastError      string
+	cachePath      string
+	endpoint       string
+	client         *http.Client
+	clientProvider func() []*http.Client
+	logger         *slog.Logger
 }
 
 func newModelMetadataStore(configPath string, logger *slog.Logger) *modelMetadataStore {
@@ -78,6 +79,29 @@ func newModelMetadataStore(configPath string, logger *slog.Logger) *modelMetadat
 		store.lastError = "load metadata cache: " + err.Error()
 	}
 	return store
+}
+
+// SetClientProvider supplies candidate HTTP clients for refresh attempts, most
+// preferred first. It lets the periodic models.dev refresh ride the proxy
+// transports exposed by whichever gateway runtime is currently active.
+func (store *modelMetadataStore) SetClientProvider(provider func() []*http.Client) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.clientProvider = provider
+}
+
+func (store *modelMetadataStore) refreshClients() []*http.Client {
+	store.mu.RLock()
+	provider := store.clientProvider
+	store.mu.RUnlock()
+	if provider == nil {
+		return []*http.Client{store.client}
+	}
+	clients := provider()
+	if len(clients) == 0 {
+		return []*http.Client{store.client}
+	}
+	return clients
 }
 
 func (store *modelMetadataStore) Start(ctx context.Context) {
@@ -109,41 +133,53 @@ func (store *modelMetadataStore) refreshAndLog(ctx context.Context) {
 }
 
 func (store *modelMetadataStore) Refresh(ctx context.Context) error {
+	var lastErr error
+	for _, client := range store.refreshClients() {
+		data, err := store.fetch(ctx, client)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		models, err := decodeModelsDev(data)
+		if err != nil {
+			return store.recordError(err)
+		}
+		now := time.Now().UTC()
+		cache := modelMetadataCache{UpdatedAt: now, Models: models}
+		if store.cachePath != "" {
+			if err := saveMetadataCache(store.cachePath, cache); err != nil {
+				return store.recordError(err)
+			}
+		}
+		store.mu.Lock()
+		store.models, store.updatedAt, store.lastError = models, now, ""
+		store.mu.Unlock()
+		return nil
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no HTTP client available for models.dev refresh")
+	}
+	return store.recordError(lastErr)
+}
+
+func (store *modelMetadataStore) fetch(ctx context.Context, client *http.Client) ([]byte, error) {
 	refreshCtx, cancel := context.WithTimeout(ctx, modelsDevTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(refreshCtx, http.MethodGet, store.endpoint, nil)
 	if err != nil {
-		return store.recordError(err)
+		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", opencodeUserAgent())
-	resp, err := store.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		return store.recordError(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
-		return store.recordError(fmt.Errorf("models.dev returned HTTP %d", resp.StatusCode))
+		return nil, fmt.Errorf("models.dev returned HTTP %d", resp.StatusCode)
 	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
-	if err != nil {
-		return store.recordError(err)
-	}
-	models, err := decodeModelsDev(data)
-	if err != nil {
-		return store.recordError(err)
-	}
-	now := time.Now().UTC()
-	cache := modelMetadataCache{UpdatedAt: now, Models: models}
-	if store.cachePath != "" {
-		if err := saveMetadataCache(store.cachePath, cache); err != nil {
-			return store.recordError(err)
-		}
-	}
-	store.mu.Lock()
-	store.models, store.updatedAt, store.lastError = models, now, ""
-	store.mu.Unlock()
-	return nil
+	return io.ReadAll(io.LimitReader(resp.Body, 32<<20))
 }
 
 func (store *modelMetadataStore) recordError(err error) error {

--- a/runtime.go
+++ b/runtime.go
@@ -52,6 +52,21 @@ func NewRuntimeManager(root context.Context, configPath string, cfg Config, logg
 		effective: effectiveListeners{API: cfg.Listen, WebUI: cfg.WebUI.Listen, WebUIEnabled: cfg.WebUI.Enabled},
 	}
 	manager.metadata = newModelMetadataStore(configPath, logger)
+	// models.dev refreshes ride the active runtime's healthy proxy transports
+	// and fall back to the store's direct client when none are available.
+	manager.metadata.SetClientProvider(func() []*http.Client {
+		runtime := manager.current.Load()
+		if runtime == nil || runtime.gateway == nil || runtime.gateway.transports == nil {
+			return nil
+		}
+		clients := make([]*http.Client, 0, len(runtime.gateway.transports.items))
+		for _, proxy := range runtime.gateway.transports.items {
+			if proxy != nil && proxy.healthy.Load() {
+				clients = append(clients, proxy.client)
+			}
+		}
+		return clients
+	})
 	if cfg.WebUI.Password != "" {
 		hash, err := hashPassword(cfg.WebUI.Password)
 		if err != nil {


### PR DESCRIPTION
## Problem

The models.dev metadata store (price / deprecation info used for anonymous-mode free-model detection) creates its own plain `http.Client`:

```go
client: &http.Client{Timeout: modelsDevTimeout}
```

This client is completely disconnected from the configured proxy pool, so the 24h periodic refresh always goes out **direct**, even when `proxies` is fully functional. On networks where direct access to `models.dev/api.json` is blocked or unstable, the refresh fails forever (`context deadline exceeded` / `connection reset by peer`), the disk cache never gets written, and anonymous eligibility silently degrades to name-based `free` matching only.

## Change

- `modelMetadataStore` gains a `clientProvider func() []*http.Client` guarded by the existing mutex. When set, `Refresh` tries each candidate client in order (fetch extracted into a small `fetch` helper) and only records an error after all candidates fail.
- `RuntimeManager` wires the provider once at startup: it resolves candidates lazily from `m.current.Load()`, returning the **active runtime's healthy proxy transports**. Because the provider reads the current runtime atomically, WebUI hot reloads that swap the gateway/proxy pool are picked up automatically — no changes needed on the Apply path.
- Empty provider result falls back to the store's original direct client, so behavior is unchanged when no proxy is configured or none are healthy.

## Testing

- `go vet ./` clean, builds with Go 1.24.
- Ran with `proxies: [http://127.0.0.1:7897, direct]` on a network where `models.dev` is unreachable directly:
  - Before: every startup logs `metadata_refresh_failed`.
  - After: `metadata_refreshed models=93` at startup, `config.json.models.dev.json` cache written (0600), and one additional zero-cost model without `free` in its name now passes anonymous-eligibility checks.
- Verified normal inference still works through the same pool afterwards.

Happy to adjust the fallback order or add unit tests if you have a preferred pattern.