### PR TITLE
feat: auto-retry upstream 400 on stale reasoning references

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -371,12 +371,18 @@ func (g *Gateway) prepareRouteBodies(from Protocol, route modelRoute, input map[
 }
 
 func (g *Gateway) doUpstream(ctx context.Context, route modelRoute, bodies map[Tier][]byte, ids requestIDs) (*http.Response, modelRoute, error) {
-	resp, effectiveRoute, err := g.doUpstreamTiers(ctx, route, bodies, ids)
+	resp, effectiveRoute, attempts, err := g.doUpstreamTiers(ctx, route, bodies, ids, 0)
 	if err != nil || resp == nil || resp.StatusCode != http.StatusBadRequest {
 		return resp, effectiveRoute, err
 	}
-	errBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	origBody := resp.Body
+	errBody, readErr := io.ReadAll(io.LimitReader(origBody, 1<<20))
+	// The original network body is always closed here: the retry path below
+	// reuses the connection, otherwise downstream receives a fresh in-memory
+	// reader over the cached bytes.
+	drainAndClose(origBody)
 	if readErr != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(errBody))
 		return resp, effectiveRoute, nil
 	}
 	// Restore the body so downstream error handling still sees the original
@@ -392,30 +398,38 @@ func (g *Gateway) doUpstream(ctx context.Context, route modelRoute, bodies map[T
 	// The referenced reasoning items belong to an upstream chain this session
 	// can no longer address (e.g. an interrupted stream). Replay once without
 	// them under a fresh upstream session instead of failing the client
-	// request outright.
-	drainAndClose(resp.Body)
+	// request outright. Attempt numbering continues from the first round so
+	// monitoring never shows duplicate attempt numbers for one request.
 	retryIDs := ids
 	retryIDs.Session = randomID("ses", 12)
-	g.logger.Info("retrying upstream without stale reasoning references", "component", "upstream", "event", "reasoning_reference_retry", "request_id", ids.Request, "model", route.ID, "tier", effectiveRoute.Tier)
-	retryResp, retryRoute, retryErr := g.doUpstreamTiers(ctx, effectiveRoute, stripped, retryIDs)
-	if retryErr != nil || retryResp == nil {
-		g.logger.Warn("reasoning reference retry failed; returning original error", "component", "upstream", "event", "reasoning_reference_retry_failed", "request_id", ids.Request, "model", route.ID, "tier", effectiveRoute.Tier, "error", retryErr)
+	g.logger.Info("retrying upstream without stale reasoning references", "component", "upstream", "event", "reasoning_reference_retry", "request_id", ids.Request, "model", route.ID, "tier", effectiveRoute.Tier, "attempt_offset", attempts)
+	retryResp, retryRoute, _, retryErr := g.doUpstreamTiers(ctx, effectiveRoute, stripped, retryIDs, attempts)
+	if retryErr != nil || retryResp == nil || retryResp.StatusCode/100 != 2 {
+		retryStatus := 0
+		if retryResp != nil {
+			retryStatus = retryResp.StatusCode
+			drainAndClose(retryResp.Body)
+		}
+		g.logger.Warn("reasoning reference retry failed; returning original error", "component", "upstream", "event", "reasoning_reference_retry_failed", "request_id", ids.Request, "model", route.ID, "tier", effectiveRoute.Tier, "error", retryErr, "retry_status", retryStatus)
 		fallback := *resp
 		fallback.Body = io.NopCloser(bytes.NewReader(errBody))
 		return &fallback, effectiveRoute, nil
 	}
-	return retryResp, retryRoute, retryErr
+	return retryResp, retryRoute, nil
 }
 
 // isStaleReasoningReference reports whether an upstream 400 body describes a
-// reasoning reference the server no longer recognizes, such as
+// reasoning item/reference the server no longer recognizes, such as
 // "Referenced reasoning item 'rs_...' was not found or has expired".
+// Generic validation errors that merely mention reasoning (e.g. "unknown
+// reasoning field") must NOT match, so both the target phrase and the
+// gone/expired marker are required.
 func isStaleReasoningReference(body []byte) bool {
 	text := strings.ToLower(string(body))
-	if !strings.Contains(text, "reasoning") {
+	if !strings.Contains(text, "reasoning item") && !strings.Contains(text, "reasoning reference") {
 		return false
 	}
-	for _, marker := range []string{"not found", "expir", "unknown", "no longer", "does not exist", "invalid reference"} {
+	for _, marker := range []string{"not found", "expir", "does not exist", "no longer"} {
 		if strings.Contains(text, marker) {
 			return true
 		}
@@ -473,16 +487,16 @@ func stripStaleReasoningInputs(route modelRoute, bodies map[Tier][]byte) (map[Ti
 	return out, changed
 }
 
-func (g *Gateway) doUpstreamTiers(ctx context.Context, route modelRoute, bodies map[Tier][]byte, ids requestIDs) (*http.Response, modelRoute, error) {
+func (g *Gateway) doUpstreamTiers(ctx context.Context, route modelRoute, bodies map[Tier][]byte, ids requestIDs, attemptOffset int) (*http.Response, modelRoute, int, error) {
 	var lastResponse *http.Response
 	var lastErr error
 	effectiveRoute := route
-	attempts := 0
+	attempts := attemptOffset
 	if route.Anonymous {
-		resp, err, used := g.doAnonymousUpstream(ctx, route, bodies, ids)
+		resp, err, used := g.doAnonymousUpstream(ctx, route, bodies, ids, attempts)
 		attempts += used
 		if err == nil && resp != nil && resp.StatusCode/100 == 2 {
-			return resp, route, nil
+			return resp, route, attempts, nil
 		}
 		lastResponse, lastErr = resp, err
 		if len(route.KeyTiers) > 0 {
@@ -507,24 +521,24 @@ func (g *Gateway) doUpstreamTiers(ctx context.Context, route modelRoute, bodies 
 		resp, err, used := g.doKeyUpstream(ctx, keyRoute, bodies, ids, attempts)
 		attempts += used
 		if err == nil && resp != nil && resp.StatusCode/100 == 2 {
-			return resp, keyRoute, nil
+			return resp, keyRoute, attempts, nil
 		}
 		lastResponse, lastErr = resp, err
 	}
 	if lastResponse != nil {
-		return lastResponse, effectiveRoute, nil
+		return lastResponse, effectiveRoute, attempts, nil
 	}
 	if lastErr == nil {
 		lastErr = errors.New("no usable upstream route")
 	}
-	return nil, effectiveRoute, lastErr
+	return nil, effectiveRoute, attempts, lastErr
 }
 
 // doAnonymousUpstream tries every currently available proxy at most once. Any
 // failure, including an HTTP error response, advances to the next proxy. Only a
 // successful response ends the anonymous phase; exhausting the proxy cursor
 // returns control to the preferred authenticated tiers.
-func (g *Gateway) doAnonymousUpstream(ctx context.Context, route modelRoute, bodies map[Tier][]byte, ids requestIDs) (*http.Response, error, int) {
+func (g *Gateway) doAnonymousUpstream(ctx context.Context, route modelRoute, bodies map[Tier][]byte, ids requestIDs, attemptOffset int) (*http.Response, error, int) {
 	var lastResponse *http.Response
 	var lastErr error
 	cursor := g.anonymous.CursorFor(ids.Session)
@@ -541,7 +555,7 @@ func (g *Gateway) doAnonymousUpstream(ctx context.Context, route modelRoute, bod
 		}
 		attempts++
 		if meta, _ := ctx.Value(requestMetaKey{}).(*requestMeta); meta != nil {
-			meta.Attempts = attempts
+			meta.Attempts = attemptOffset + attempts
 			meta.Tier = string(TierZen)
 		}
 		if lastResponse != nil {
@@ -561,7 +575,7 @@ func (g *Gateway) doAnonymousUpstream(ctx context.Context, route modelRoute, bod
 			status = resp.StatusCode
 		}
 		g.syncProxyResult(ctx, node.proxy, status, err)
-		g.recordUpstreamAttempt(route, ids, attempts, "anonymous", "anonymous", true, node.proxy, resp, err, duration)
+		g.recordUpstreamAttempt(route, ids, attemptOffset+attempts, "anonymous", "anonymous", true, node.proxy, resp, err, duration)
 		if err == nil && resp.StatusCode/100 == 2 {
 			g.anonymous.MarkSuccess(node)
 			g.logger.Debug("anonymous upstream accepted request", "component", "upstream", "event", "anonymous_attempt_succeeded", "request_id", ids.Request, "attempt", attempts, "tier", TierZen, "key_id", "anonymous", "channel", "anonymous", "anonymous", true, "proxy", redactURL(node.proxy.name), "status", resp.StatusCode, "duration_ms", duration.Milliseconds())

--- a/gateway.go
+++ b/gateway.go
@@ -371,6 +371,109 @@ func (g *Gateway) prepareRouteBodies(from Protocol, route modelRoute, input map[
 }
 
 func (g *Gateway) doUpstream(ctx context.Context, route modelRoute, bodies map[Tier][]byte, ids requestIDs) (*http.Response, modelRoute, error) {
+	resp, effectiveRoute, err := g.doUpstreamTiers(ctx, route, bodies, ids)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusBadRequest {
+		return resp, effectiveRoute, err
+	}
+	errBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if readErr != nil {
+		return resp, effectiveRoute, nil
+	}
+	// Restore the body so downstream error handling still sees the original
+	// payload when no retry happens below.
+	resp.Body = io.NopCloser(bytes.NewReader(errBody))
+	if !isStaleReasoningReference(errBody) {
+		return resp, effectiveRoute, nil
+	}
+	stripped, changed := stripStaleReasoningInputs(effectiveRoute, bodies)
+	if !changed {
+		return resp, effectiveRoute, nil
+	}
+	// The referenced reasoning items belong to an upstream chain this session
+	// can no longer address (e.g. an interrupted stream). Replay once without
+	// them under a fresh upstream session instead of failing the client
+	// request outright.
+	drainAndClose(resp.Body)
+	retryIDs := ids
+	retryIDs.Session = randomID("ses", 12)
+	g.logger.Info("retrying upstream without stale reasoning references", "component", "upstream", "event", "reasoning_reference_retry", "request_id", ids.Request, "model", route.ID, "tier", effectiveRoute.Tier)
+	retryResp, retryRoute, retryErr := g.doUpstreamTiers(ctx, effectiveRoute, stripped, retryIDs)
+	if retryErr != nil || retryResp == nil {
+		g.logger.Warn("reasoning reference retry failed; returning original error", "component", "upstream", "event", "reasoning_reference_retry_failed", "request_id", ids.Request, "model", route.ID, "tier", effectiveRoute.Tier, "error", retryErr)
+		fallback := *resp
+		fallback.Body = io.NopCloser(bytes.NewReader(errBody))
+		return &fallback, effectiveRoute, nil
+	}
+	return retryResp, retryRoute, retryErr
+}
+
+// isStaleReasoningReference reports whether an upstream 400 body describes a
+// reasoning reference the server no longer recognizes, such as
+// "Referenced reasoning item 'rs_...' was not found or has expired".
+func isStaleReasoningReference(body []byte) bool {
+	text := strings.ToLower(string(body))
+	if !strings.Contains(text, "reasoning") {
+		return false
+	}
+	for _, marker := range []string{"not found", "expir", "unknown", "no longer", "does not exist", "invalid reference"} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripStaleReasoningInputs removes server-issued reasoning references from
+// Responses-protocol upstream payloads: replayed "reasoning" input items and
+// any previous_response_id chain link. Other tiers/protocols are passed
+// through untouched. It reports whether any payload actually changed.
+func stripStaleReasoningInputs(route modelRoute, bodies map[Tier][]byte) (map[Tier][]byte, bool) {
+	changed := false
+	out := make(map[Tier][]byte, len(bodies))
+	for tier, body := range bodies {
+		if len(body) == 0 || route.ProtocolFor(tier) != ProtocolResponses {
+			out[tier] = body
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			out[tier] = body
+			continue
+		}
+		tierChanged := false
+		if _, ok := payload["previous_response_id"]; ok {
+			delete(payload, "previous_response_id")
+			tierChanged = true
+		}
+		if raw, ok := payload["input"].([]any); ok {
+			kept := make([]any, 0, len(raw))
+			for _, item := range raw {
+				if m, ok := item.(map[string]any); ok && stringAt(m, "type") == "reasoning" {
+					tierChanged = true
+					continue
+				}
+				kept = append(kept, item)
+			}
+			if tierChanged {
+				payload["input"] = kept
+			}
+		}
+		if !tierChanged {
+			out[tier] = body
+			continue
+		}
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			out[tier] = body
+			continue
+		}
+		out[tier] = encoded
+		changed = true
+	}
+	return out, changed
+}
+
+func (g *Gateway) doUpstreamTiers(ctx context.Context, route modelRoute, bodies map[Tier][]byte, ids requestIDs) (*http.Response, modelRoute, error) {
 	var lastResponse *http.Response
 	var lastErr error
 	effectiveRoute := route

--- a/gateway_retry_test.go
+++ b/gateway_retry_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIsStaleReasoningReference(t *testing.T) {
+	cases := []struct {
+		body string
+		want bool
+	}{
+		{`{"error":{"message":"Upstream request failed: [invalid_request_error] Referenced reasoning item 'rs_7145a5ca29c1537d081efdb1' was not found or has expired.", "type":"invalid_request_error"}}`, true},
+		{`{"error":{"message":"reasoning item rs_abc has expired", "type":"invalid_request_error"}}`, true},
+		{`{"error":{"message":"Model is unavailable.", "type":"upstream_error"}}`, false},
+		{`{"error":{"message":"invalid_request_error: missing field 'model'", "type":"invalid_request_error"}}`, false},
+		{`not json at all`, false},
+		{``, false},
+	}
+	for _, tc := range cases {
+		if got := isStaleReasoningReference([]byte(tc.body)); got != tc.want {
+			t.Errorf("isStaleReasoningReference(%q) = %v, want %v", tc.body, got, tc.want)
+		}
+	}
+}
+
+func TestStripStaleReasoningInputs(t *testing.T) {
+	route := modelRoute{
+		ID:        "test-model",
+		Tier:      TierZen,
+		Protocol:  ProtocolResponses,
+		Protocols: map[Tier]Protocol{TierZen: ProtocolResponses, TierGo: ProtocolChat},
+	}
+	responsesBody := []byte(`{"model":"test-model","previous_response_id":"resp_123","input":[{"type":"reasoning","id":"rs_old","summary":[]},{"type":"message","role":"user","content":"hi"}]}`)
+	chatBody := []byte(`{"model":"test-model","messages":[{"role":"user","content":"hi"}]}`)
+	bodies := map[Tier][]byte{TierZen: responsesBody, TierGo: chatBody}
+
+	stripped, changed := stripStaleReasoningInputs(route, bodies)
+	if !changed {
+		t.Fatal("expected changed=true when reasoning references exist")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stripped[TierZen], &payload); err != nil {
+		t.Fatalf("stripped zen body is not valid JSON: %v", err)
+	}
+	if _, ok := payload["previous_response_id"]; ok {
+		t.Error("previous_response_id was not removed")
+	}
+	input, _ := payload["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("expected 1 input item left, got %d", len(input))
+	}
+	if m, _ := input[0].(map[string]any); stringAt(m, "type") != "message" {
+		t.Errorf("unexpected remaining input item: %v", input[0])
+	}
+	if string(stripped[TierGo]) != string(chatBody) {
+		t.Error("non-Responses tier body must pass through untouched")
+	}
+
+	cleanBodies := map[Tier][]byte{TierZen: []byte(`{"model":"m","input":[{"type":"message","role":"user","content":"hi"}]}`)}
+	if _, changed := stripStaleReasoningInputs(route, cleanBodies); changed {
+		t.Error("expected changed=false when no reasoning references exist")
+	}
+}

--- a/gateway_retry_test.go
+++ b/gateway_retry_test.go
@@ -1,7 +1,14 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -12,8 +19,12 @@ func TestIsStaleReasoningReference(t *testing.T) {
 	}{
 		{`{"error":{"message":"Upstream request failed: [invalid_request_error] Referenced reasoning item 'rs_7145a5ca29c1537d081efdb1' was not found or has expired.", "type":"invalid_request_error"}}`, true},
 		{`{"error":{"message":"reasoning item rs_abc has expired", "type":"invalid_request_error"}}`, true},
+		{`{"error":{"message":"Reasoning reference rs_xyz does not exist", "type":"invalid_request_error"}}`, true},
+		// Negative cases: generic errors that merely mention reasoning must not match.
 		{`{"error":{"message":"Model is unavailable.", "type":"upstream_error"}}`, false},
-		{`{"error":{"message":"invalid_request_error: missing field 'model'", "type":"invalid_request_error"}}`, false},
+		{`{"error":{"message":"unknown reasoning field 'foo'", "type":"invalid_request_error"}}`, false},
+		{`{"error":{"message":"invalid reasoning_effort value 'high'", "type":"invalid_request_error"}}`, false},
+		{`{"error":{"message":"request body must be a JSON object", "type":"invalid_request_error"}}`, false},
 		{`not json at all`, false},
 		{``, false},
 	}
@@ -60,5 +71,223 @@ func TestStripStaleReasoningInputs(t *testing.T) {
 	cleanBodies := map[Tier][]byte{TierZen: []byte(`{"model":"m","input":[{"type":"message","role":"user","content":"hi"}]}`)}
 	if _, changed := stripStaleReasoningInputs(route, cleanBodies); changed {
 		t.Error("expected changed=false when no reasoning references exist")
+	}
+}
+
+const retryTestStaleError = `{"error":{"message":"Upstream request failed: [invalid_request_error] Referenced reasoning item 'rs_old' was not found or has expired.", "type":"invalid_request_error"}}`
+
+func retryTestUpstreamBody() []byte {
+	return []byte(`{"model":"test-model","previous_response_id":"resp_123","input":[{"type":"reasoning","id":"rs_old","summary":[{"type":"summary_text","text":"thinking"}]},{"type":"message","role":"user","content":"hi"}]}`)
+}
+
+func newRetryTestGateway(t *testing.T, upstreamURL string) *Gateway {
+	t.Helper()
+	cfg := Config{
+		ServerKeys:  []string{"test-key"},
+		Anonymous:   true,
+		Proxies:     []string{"direct"},
+		Upstream:    UpstreamConfig{Zen: upstreamURL, Go: upstreamURL},
+		Retry:       RetryConfig{MaxAttempts: 3, TimeoutSeconds: 30},
+		Performance: PerformanceConfig{MaxIdleConns: 32, MaxIdleConnsPerHost: 8, ConnectTimeoutSeconds: 5, FailureCooldownSeconds: 1},
+		Prefer:      TierZen,
+		Models:      ModelsConfig{RefreshSeconds: 300, Protocols: map[string]string{}},
+		Logging:     LoggingConfig{Level: "error", RingSize: 100},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	g, err := NewGateway(cfg, logger, NewMonitor())
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	return g
+}
+
+func retryTestRoute() modelRoute {
+	return modelRoute{
+		ID:        "test-model",
+		Tier:      TierZen,
+		Protocol:  ProtocolResponses,
+		Protocols: map[Tier]Protocol{TierZen: ProtocolResponses},
+		Anonymous: true,
+	}
+}
+
+func retryTestIDs() requestIDs {
+	return requestIDs{Session: "ses_test", Request: "req_test", Project: "prj_test"}
+}
+
+func upstreamInputHasReasoning(t *testing.T, raw []byte) bool {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("upstream request is not valid JSON: %v", err)
+	}
+	if _, ok := payload["previous_response_id"]; ok {
+		return true
+	}
+	for _, item := range sliceAt(payload, "input") {
+		if m, ok := item.(map[string]any); ok && stringAt(m, "type") == "reasoning" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDoUpstreamRetriesStaleReasoningSuccess(t *testing.T) {
+	var hits atomic.Int64
+	var secondBody atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(retryTestStaleError))
+			return
+		}
+		secondBody.Store(body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"resp_1","status":"completed"}`))
+	}))
+	defer server.Close()
+
+	g := newRetryTestGateway(t, server.URL)
+	resp, _, err := g.doUpstream(context.Background(), retryTestRoute(), map[Tier][]byte{TierZen: retryTestUpstreamBody()}, retryTestIDs())
+	if err != nil {
+		t.Fatalf("doUpstream: %v", err)
+	}
+	defer drainAndClose(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after retry, got %d", resp.StatusCode)
+	}
+	if hits.Load() != 2 {
+		t.Fatalf("expected 2 upstream hits, got %d", hits.Load())
+	}
+	raw, _ := secondBody.Load().([]byte)
+	if upstreamInputHasReasoning(t, raw) {
+		t.Errorf("retry request still carries reasoning references: %s", raw)
+	}
+}
+
+func TestDoUpstreamRetryNon2xxRestoresOriginal(t *testing.T) {
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(retryTestStaleError))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"boom", "type":"server_error"}}`))
+	}))
+	defer server.Close()
+
+	g := newRetryTestGateway(t, server.URL)
+	resp, _, err := g.doUpstream(context.Background(), retryTestRoute(), map[Tier][]byte{TierZen: retryTestUpstreamBody()}, retryTestIDs())
+	if err != nil {
+		t.Fatalf("doUpstream: %v", err)
+	}
+	defer drainAndClose(resp.Body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected original 400, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if strings.TrimSpace(string(body)) != retryTestStaleError {
+		t.Errorf("expected original error body restored, got %q", body)
+	}
+	if hits.Load() != 2 {
+		t.Fatalf("expected 2 upstream hits, got %d", hits.Load())
+	}
+}
+
+func TestDoUpstreamNonMatching400PassesThrough(t *testing.T) {
+	var hits atomic.Int64
+	const unavailable = `{"error":{"message":"Model is unavailable.", "type":"upstream_error"}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(unavailable))
+	}))
+	defer server.Close()
+
+	g := newRetryTestGateway(t, server.URL)
+	resp, _, err := g.doUpstream(context.Background(), retryTestRoute(), map[Tier][]byte{TierZen: retryTestUpstreamBody()}, retryTestIDs())
+	if err != nil {
+		t.Fatalf("doUpstream: %v", err)
+	}
+	defer drainAndClose(resp.Body)
+	if hits.Load() != 1 {
+		t.Fatalf("expected no retry, got %d upstream hits", hits.Load())
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if strings.TrimSpace(string(body)) != unavailable {
+		t.Errorf("expected passthrough body, got %q", body)
+	}
+}
+
+func TestDoUpstreamStaleErrorWithoutReasoningNoRetry(t *testing.T) {
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(retryTestStaleError))
+	}))
+	defer server.Close()
+
+	g := newRetryTestGateway(t, server.URL)
+	clean := []byte(`{"model":"test-model","input":[{"type":"message","role":"user","content":"hi"}]}`)
+	resp, _, err := g.doUpstream(context.Background(), retryTestRoute(), map[Tier][]byte{TierZen: clean}, retryTestIDs())
+	if err != nil {
+		t.Fatalf("doUpstream: %v", err)
+	}
+	defer drainAndClose(resp.Body)
+	if hits.Load() != 1 {
+		t.Fatalf("expected no retry when payload has nothing to strip, got %d hits", hits.Load())
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestDoUpstreamRetryAttemptsAreCumulative(t *testing.T) {
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(retryTestStaleError))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"resp_1","status":"completed"}`))
+	}))
+	defer server.Close()
+
+	monitor := NewMonitor()
+	cfg := Config{
+		ServerKeys:  []string{"test-key"},
+		Anonymous:   true,
+		Proxies:     []string{"direct"},
+		Upstream:    UpstreamConfig{Zen: server.URL, Go: server.URL},
+		Retry:       RetryConfig{MaxAttempts: 3, TimeoutSeconds: 30},
+		Performance: PerformanceConfig{MaxIdleConns: 32, MaxIdleConnsPerHost: 8, ConnectTimeoutSeconds: 5, FailureCooldownSeconds: 1},
+		Prefer:      TierZen,
+		Models:      ModelsConfig{RefreshSeconds: 300, Protocols: map[string]string{}},
+		Logging:     LoggingConfig{Level: "error", RingSize: 100},
+	}
+	g, err := NewGateway(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)), monitor)
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	resp, _, err := g.doUpstream(context.Background(), retryTestRoute(), map[Tier][]byte{TierZen: retryTestUpstreamBody()}, retryTestIDs())
+	if err != nil {
+		t.Fatalf("doUpstream: %v", err)
+	}
+	drainAndClose(resp.Body)
+	var numbers []int
+	for _, attempt := range monitor.Snapshot().Upstream.Recent {
+		if attempt.RequestID == "req_test" {
+			numbers = append(numbers, attempt.Attempt)
+		}
+	}
+	if len(numbers) != 2 || numbers[0] != 1 || numbers[1] != 2 {
+		t.Errorf("expected cumulative attempt numbers [1 2], got %v", numbers)
 	}
 }


### PR DESCRIPTION
## Problem

When a Responses-native model (e.g. muse-spark-1.3) is called through the Anthropic Messages API, the bridge replays reasoning history as Responses `reasoning` input items with gateway-generated `rs_...` ids. If the upstream Zen session can no longer address that chain (e.g. after an interrupted stream + client retry), Zen answers:

```
400 [invalid_request_error] Referenced reasoning item 'rs_...' was not found or has expired.
```

The gateway previously forwarded this 400 straight to the client (a single anonymous proxy means exactly one attempt), so Claude Code-style clients surface a hard API error even though a retry would succeed.

## Fix

Wrap `doUpstream`: when the final upstream response is a 400 whose body mentions `reasoning` plus (`not found` / `expir` / `unknown` / …), replay **once** without the stale references — strip `reasoning` items and `previous_response_id` from Responses-protocol payloads and resend under a fresh upstream session id (client `request_id` unchanged for tracing).

- Only this error signature triggers the extra attempt; all other 400s (e.g. `Model is unavailable`) and non-Responses payloads pass through untouched.
- If the retry also fails, the original 400 is returned, preserving previous behavior.
- Always on, no config changes (`DisallowUnknownFields` safe).
- Emits `reasoning_reference_retry` / `reasoning_reference_retry_failed` log events.

## Tests

- New `gateway_retry_test.go`: classifier cases (real error text, unrelated 400s, non-JSON) and payload stripping (reasoning removal, `previous_response_id` removal, non-Responses tier passthrough, no-op detection).
- `go vet` clean; live regression against anonymous Zen: health 200, single-turn and multi-turn (with thinking history) inference 200.