### PR TITLE
feat: bound anonymous attempt header wait and stop scanning on expired context

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ cp config.example.json config.json
     "max_conns_per_host": 0,
     "idle_conn_timeout_seconds": 120,
     "connect_timeout_seconds": 5,
-    "failure_cooldown_seconds": 15
+    "failure_cooldown_seconds": 15,
+    "attempt_timeout_seconds": 0
   },
   "logging": {
     "level": "info",
@@ -342,6 +343,7 @@ socks5://127.0.0.1:1080  # 备用代理
 | `performance.idle_conn_timeout_seconds` | 空闲连接在连接池中保留的时间。 |
 | `performance.connect_timeout_seconds` | 与上游或代理建立 TCP 连接的超时时间。 |
 | `performance.failure_cooldown_seconds` | 连接失败、认证失败、限流或 5xx 后节点的基础冷却时间。连续失败会指数增加冷却时间。 |
+| `performance.attempt_timeout_seconds` | 单次上游尝试等待响应头（首字节）的上限，单位秒。`0` 表示沿用 `retry.timeout_seconds`（默认行为）；设置后不会超过请求级超时。只限制建连后的首字节等待，已建立的流不受影响。 |
 
 ### `logging`
 

--- a/config.example.json
+++ b/config.example.json
@@ -25,7 +25,8 @@
     "max_conns_per_host": 0,
     "idle_conn_timeout_seconds": 120,
     "connect_timeout_seconds": 5,
-    "failure_cooldown_seconds": 15
+    "failure_cooldown_seconds": 15,
+    "attempt_timeout_seconds": 0
   },
   "logging": {
     "level": "info",

--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 type Config struct {
@@ -69,6 +70,23 @@ type PerformanceConfig struct {
 	IdleConnTimeoutSeconds int `json:"idle_conn_timeout_seconds"`
 	ConnectTimeoutSeconds  int `json:"connect_timeout_seconds"`
 	FailureCooldownSeconds int `json:"failure_cooldown_seconds"`
+	AttemptTimeoutSeconds  int `json:"attempt_timeout_seconds"`
+}
+
+// AnonymousAttemptTimeout bounds how long a single upstream attempt may wait
+// for response headers. Values <= 0 keep the historical behavior of using the
+// request-level retry timeout, so existing configs are unaffected. The result
+// never exceeds requestTimeout. Only the header wait is bounded: established
+// streams keep flowing under the request-level timeout.
+func (cfg PerformanceConfig) AnonymousAttemptTimeout(requestTimeout time.Duration) time.Duration {
+	if cfg.AttemptTimeoutSeconds > 0 {
+		attempt := time.Duration(cfg.AttemptTimeoutSeconds) * time.Second
+		if requestTimeout > 0 && attempt > requestTimeout {
+			return requestTimeout
+		}
+		return attempt
+	}
+	return requestTimeout
 }
 
 func LoadConfig(path string) (Config, error) {
@@ -142,6 +160,9 @@ func NormalizeConfig(path string, cfg Config) (Config, error) {
 	}
 	if cfg.Performance.MaxIdleConns < 1 || cfg.Performance.MaxIdleConnsPerHost < 1 || cfg.Performance.MaxConnsPerHost < 0 || cfg.Performance.IdleConnTimeoutSeconds < 1 || cfg.Performance.ConnectTimeoutSeconds < 1 || cfg.Performance.FailureCooldownSeconds < 1 {
 		return Config{}, errors.New("performance values must be positive (max_conns_per_host may be zero for unlimited)")
+	}
+	if cfg.Performance.AttemptTimeoutSeconds < 0 {
+		return Config{}, errors.New("performance.attempt_timeout_seconds must not be negative (0 keeps the retry timeout)")
 	}
 	if cfg.Logging.Level != "debug" && cfg.Logging.Level != "info" && cfg.Logging.Level != "warn" && cfg.Logging.Level != "error" {
 		return Config{}, errors.New("logging.level must be debug, info, warn, or error")

--- a/gateway.go
+++ b/gateway.go
@@ -72,7 +72,7 @@ type healthProxies struct {
 }
 
 func NewGateway(cfg Config, logger *slog.Logger, monitor *Monitor) (*Gateway, error) {
-	transports, err := newTransportPool(cfg.RuntimeProxies(), cfg.Performance, time.Duration(cfg.Retry.TimeoutSeconds)*time.Second)
+	transports, err := newTransportPool(cfg.RuntimeProxies(), cfg.Performance, cfg.Performance.AnonymousAttemptTimeout(time.Duration(cfg.Retry.TimeoutSeconds)*time.Second))
 	if err != nil {
 		return nil, err
 	}
@@ -586,6 +586,15 @@ func (g *Gateway) doAnonymousUpstream(ctx context.Context, route modelRoute, bod
 		return nil, errors.New("no prepared Zen request body"), 0
 	}
 	for attempts < limit {
+		if ctx.Err() != nil {
+			// The request-level budget is already exhausted. Stop scanning
+			// instead of recording phantom failures against proxies that
+			// would never really be tried.
+			if lastErr == nil {
+				lastErr = ctx.Err()
+			}
+			break
+		}
 		node := cursor.Next()
 		if node == nil {
 			break
@@ -610,6 +619,17 @@ func (g *Gateway) doAnonymousUpstream(ctx context.Context, route modelRoute, bod
 		status := 0
 		if resp != nil {
 			status = resp.StatusCode
+		}
+		if ctx.Err() != nil {
+			// The parent budget expired while this attempt was in flight.
+			// The outcome says nothing about this proxy: keep it as the
+			// last result but mark nothing and stop scanning.
+			lastResponse = resp
+			lastErr = err
+			if lastErr == nil && lastResponse == nil {
+				lastErr = ctx.Err()
+			}
+			break
 		}
 		g.syncProxyResult(ctx, node.proxy, status, err)
 		g.recordUpstreamAttempt(route, ids, attemptOffset+attempts, "anonymous", "anonymous", true, node.proxy, resp, err, duration)


### PR DESCRIPTION
## Problem (observed in production, 77-proxy anonymous pool)

Two linked failure modes, confirmed against request-level monitor data:

1. One hung upstream attempt eats the whole request budget. Attempts share a single 60s request context with no per-attempt bound (\ResponseHeaderTimeout\ == \etry.timeout_seconds\), so a single slow exit produces \ttempts: 77, duration 60s, context deadline exceeded\.
2. After the budget is gone, the loop keeps firing instant attempts against an expired context (0ms \	ransport_error\). Each one still calls \MarkFailure\/\syncProxyResult\, and \isProxyFailure\ treats \context.DeadlineExceeded\ as proxy failure — so one bad request evicts dozens of healthy proxies, followed by \
o healthy anonymous proxies available\ for subsequent requests until health checks recover them.

## Changes (4 files, +47/-3)

- \config.go\: new \performance.attempt_timeout_seconds\ (\